### PR TITLE
Fix some compilation issues blocking .NET 3.5 / Unity 2017.3.0f3 project integration

### DIFF
--- a/GroundKontrol/Editor/MidiControllerInspector.cs
+++ b/GroundKontrol/Editor/MidiControllerInspector.cs
@@ -72,9 +72,8 @@ internal class SelectedItem
         )
         .Where(o => _isNumber(o.FieldType));
 
-    return fields.Concat<MemberInfo>(properties)
-        .Select((m) => m.Name)
-        .ToList();
+
+    return fields.Select((m) => m.Name).Concat(properties.Select((m) => m.Name)).ToList();
   }
 
   private static bool _isNumber(Type t)
@@ -137,7 +136,7 @@ public class MidiControllerInspector : Editor
 
     // TODO: Buttons as boolean toggles?
 
-    if (item.Members.Count > 0)
+    if (item.Members.Count > 0 && item.MemberIndex >= 0)
     {
       item.MemberIndex =
           EditorGUILayout.Popup("Property", item.MemberIndex, item.Members.ToArray(), EditorStyles.popup);

--- a/GroundKontrol/Editor/MidiControllerWindow.cs
+++ b/GroundKontrol/Editor/MidiControllerWindow.cs
@@ -209,14 +209,20 @@ class MidiControllerWindow : EditorWindow
     {
       item.MemberIndex =
           EditorGUILayout.Popup("", item.MemberIndex, item.Members.ToArray(), EditorStyles.popup, GUILayout.Width(_width));
-      item.Item.Member = item.Members.ElementAt(item.MemberIndex);
+      if (item.MemberIndex >= 0)
+      {
+        item.Item.Member = item.Members.ElementAt(item.MemberIndex);
+        item.Item.Range = EditorGUILayout.DelayedIntField("Range", item.Item.Range, GUILayout.Width(_width));
+      }
 
-      item.Item.Range = EditorGUILayout.DelayedIntField("Range", item.Item.Range, GUILayout.Width(_width));
+      EditorGUILayout.LabelField("Value: ", _getValue(item).ToString());
     }
 
     EditorGUILayout.EndVertical();
     EditorGUILayout.Space();
   }
+
+  private static object _getValue(SelectedItem item) => MidiController.GetValue(item.Item, item.Object);
 
   private static bool _isNumber(Type t)
   {

--- a/GroundKontrol/MidiController.cs
+++ b/GroundKontrol/MidiController.cs
@@ -42,7 +42,10 @@ public class MidiInput
 		}
 	}
 
-	public string Name => $"{Type} {Number + 1}";
+	public string Name
+	{
+		get { return string.Format(@"{0} {1}", Type, Number + 1); }
+	}
 }
 
 [Serializable]
@@ -59,7 +62,7 @@ public class InputConfiguration
 
 	public InputConfiguration(MidiInput input)
 	{
-		Debug.Log("Creating INputConfiguration with MidiInput");
+		Debug.Log("Creating InputConfiguration with MidiInput");
 		Input = input;
 	}
 	
@@ -203,7 +206,7 @@ public class MidiController : MonoBehaviour
 			case MemberTypes.Event:
 				return ((EventInfo)member).EventHandlerType;
 			default:
-				throw new ArgumentException("MemberInfo must be if type FieldInfo, PropertyInfo or EventInfo", nameof(member));
+				throw new ArgumentException("MemberInfo must be if type FieldInfo, PropertyInfo or EventInfo");
 		}
 	}
 }

--- a/Sample/Assets/Plugins/GroundKontrol/Editor/MidiControllerInspector.cs
+++ b/Sample/Assets/Plugins/GroundKontrol/Editor/MidiControllerInspector.cs
@@ -72,9 +72,8 @@ internal class SelectedItem
         )
         .Where(o => _isNumber(o.FieldType));
 
-    return fields.Concat<MemberInfo>(properties)
-        .Select((m) => m.Name)
-        .ToList();
+
+    return fields.Select((m) => m.Name).Concat(properties.Select((m) => m.Name)).ToList();
   }
 
   private static bool _isNumber(Type t)
@@ -137,7 +136,7 @@ public class MidiControllerInspector : Editor
 
     // TODO: Buttons as boolean toggles?
 
-    if (item.Members.Count > 0)
+    if (item.Members.Count > 0 && item.MemberIndex >= 0)
     {
       item.MemberIndex =
           EditorGUILayout.Popup("Property", item.MemberIndex, item.Members.ToArray(), EditorStyles.popup);

--- a/Sample/Assets/Plugins/GroundKontrol/Editor/MidiControllerWindow.cs
+++ b/Sample/Assets/Plugins/GroundKontrol/Editor/MidiControllerWindow.cs
@@ -209,9 +209,11 @@ class MidiControllerWindow : EditorWindow
     {
       item.MemberIndex =
           EditorGUILayout.Popup("", item.MemberIndex, item.Members.ToArray(), EditorStyles.popup, GUILayout.Width(_width));
-      item.Item.Member = item.Members.ElementAt(item.MemberIndex);
-
-      item.Item.Range = EditorGUILayout.DelayedIntField("Range", item.Item.Range, GUILayout.Width(_width));
+      if (item.MemberIndex >= 0)
+      {
+        item.Item.Member = item.Members.ElementAt(item.MemberIndex);
+        item.Item.Range = EditorGUILayout.DelayedIntField("Range", item.Item.Range, GUILayout.Width(_width));
+      }
 
       EditorGUILayout.LabelField("Value: ", _getValue(item).ToString());
     }

--- a/Sample/Assets/Plugins/GroundKontrol/MidiController.cs
+++ b/Sample/Assets/Plugins/GroundKontrol/MidiController.cs
@@ -42,7 +42,10 @@ public class MidiInput
 		}
 	}
 
-	public string Name => $"{Type} {Number + 1}";
+	public string Name
+	{
+		get { return string.Format(@"{0} {1}", Type, Number + 1); }
+	}
 }
 
 [Serializable]
@@ -59,7 +62,7 @@ public class InputConfiguration
 
 	public InputConfiguration(MidiInput input)
 	{
-		Debug.Log("Creating INputConfiguration with MidiInput");
+		Debug.Log("Creating InputConfiguration with MidiInput");
 		Input = input;
 	}
 	
@@ -203,7 +206,7 @@ public class MidiController : MonoBehaviour
 			case MemberTypes.Event:
 				return ((EventInfo)member).EventHandlerType;
 			default:
-				throw new ArgumentException("MemberInfo must be if type FieldInfo, PropertyInfo or EventInfo", nameof(member));
+				throw new ArgumentException("MemberInfo must be if type FieldInfo, PropertyInfo or EventInfo");
 		}
 	}
 }


### PR DESCRIPTION
Heya @lazerwalker, loved your Tech Toolbox talk at GDC so much I ordered a nanoKONTROL2 on the spot! :) Tried it out for the first time last night when I had to test out different framerates while testing control schemes, and it's awesome! Was able to play with and resolve some long-standing game bugs that were previously challenging to hunt down.

Our game's Unity 2017.3.0f3 project targeting .NET 3.5 required a few tweaks to run without compilation errors / a UI-related null pointer exception so wanted to share these quick fixes in case anyone else is restricted to this language subset. (We may upgrade at some point, but hesitant to make changes until necessary since game is in early access.)

I made most of these modifications using JetBrains Rider's `alt+enter` auto-refactorings so should be pretty low-risk. Can definitely take or leave this PR, completely understand if you want to move forward using the cool new .NET language features!

**Issues Fixed**

- Fixed compilation error where `PropertyInfo` and `FieldInfo` types could not be `.concat`-ed
- Convert string template usage to interpolation
- Remove extra `nameof(member)` debug log info which was causing a type error
- Add workaround for issue where when `item.MemberIndex == -1` (which for me was every dropdown refresh) an index out of range exception would occur. Confirmed dropdowns now show up with the right properties.
- One small capitalization typo in a `Debug.Log`